### PR TITLE
Improvement/refactoring to idiomatic go

### DIFF
--- a/controllers/info.go
+++ b/controllers/info.go
@@ -1,21 +1,26 @@
 package controllers
 
 import (
-	"github.com/bitly/go-simplejson"
-	"github.com/ditrit/badaas/resources"
+	"encoding/json"
 	"net/http"
+
+	"github.com/ditrit/badaas/persistence/models"
+	"github.com/ditrit/badaas/resources"
 )
 
 // Info controller, return json with status and version of api.
 func Info(response http.ResponseWriter, _ *http.Request) {
-	json := simplejson.New()
-	json.Set("status", "OK")
-	json.Set("version", resources.Version)
 
-	response.WriteHeader(http.StatusOK)
-	payload, _ := json.MarshalJSON()
+	infos := models.BadaasServerInfo{
+		Status:  "OK",
+		Version: resources.Version,
+	}
 
-	response.WriteHeader(http.StatusOK)
+	payload, err := json.Marshal(&infos)
+	if err != nil {
+		http.Error(response, "error while marshaling response", http.StatusInternalServerError)
+	}
+
 	response.Header().Set("Content-Type", "application/json")
 	response.Write(payload)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,12 @@ module github.com/ditrit/badaas
 go 1.18
 
 require (
-	github.com/bitly/go-simplejson v0.5.0
 	github.com/cucumber/godog v0.12.5
 	github.com/gorilla/mux v1.8.0
 	github.com/spf13/pflag v1.0.5
 )
 
 require (
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/cucumber/gherkin-go/v19 v19.0.3 // indirect
 	github.com/cucumber/messages-go/v16 v16.0.1 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,11 +22,7 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
-github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
-github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
-github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -125,10 +121,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/http_support_test.go
+++ b/http_support_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -35,14 +34,14 @@ func (t *TestContext) storeResponseInContext(response *http.Response) {
 
 func (t *TestContext) assertStatusCode(_ context.Context, expectedStatusCode int) error {
 	if t.statusCode != expectedStatusCode {
-		return errors.New(fmt.Sprintf("expect status code %d but is %d", expectedStatusCode, t.statusCode))
+		return fmt.Errorf("expect status code %d but is %d", expectedStatusCode, t.statusCode)
 	}
 	return nil
 }
 func (t *TestContext) assertResponseFieldIsEquals(field string, expectedValue string) error {
 	value := t.json[field].(string)
 	if !assertValue(value, expectedValue) {
-		return errors.New(fmt.Sprintf("expect response field %s is %s but is %s", field, expectedValue, value))
+		return fmt.Errorf("expect response field %s is %s but is %s", field, expectedValue, value)
 	}
 	return nil
 }

--- a/http_support_test.go
+++ b/http_support_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 )
@@ -24,7 +24,7 @@ func (t *TestContext) requestGET(url string) error {
 func (t *TestContext) storeResponseInContext(response *http.Response) {
 	t.statusCode = response.StatusCode
 
-	buffer, err := ioutil.ReadAll(response.Body)
+	buffer, err := io.ReadAll(response.Body)
 	if err != nil {
 		log.Panic(err)
 	}

--- a/persistence/models/ProductInfo.go
+++ b/persistence/models/ProductInfo.go
@@ -1,0 +1,7 @@
+package models
+
+// Describe the current BADAAS instance
+type BadaasServerInfo struct {
+	Status  string `json:"status"`
+	Version string `json:"version"`
+}


### PR DESCRIPTION
- Refactor the handler for the  `/info` endpoint. The code is more idiomatic that way.
- Update the go.mod file: remove an unneeded dependency 
- remove calls to deprecated module 'io/ioutils'
